### PR TITLE
Disable add to cart-button when user is not logged in

### DIFF
--- a/app/views/restaurants/show.html.haml
+++ b/app/views/restaurants/show.html.haml
@@ -42,3 +42,5 @@
                         = hidden_field_tag :restaurant_id, @restaurant.id
                         = number_field_tag :remove_amount, 1, min: 1
                         = submit_tag 'Remove from cart', class: 'btn btn-primary'
+                - else
+                  = submit_tag 'Log in to order', disabled: true, class: 'btn btn-primary'

--- a/features/add_to_cart.feature
+++ b/features/add_to_cart.feature
@@ -56,4 +56,4 @@ Feature: user can can add dish to order
     Given the user is signed out
     Then I click "Main"
     And I should see the text "Dumplings"
-    And I should not see link "Add Dumplings to cart"
+    And I should not see link "Add to cart"


### PR DESCRIPTION
Tiny PR with a fix for a confused customer - "why can't I buy the food?!"
* Added disabled button saying "log in to order" under the dish